### PR TITLE
Added SSW Placeholders to Prompt String

### DIFF
--- a/src/Application/Services/MessageHandler.cs
+++ b/src/Application/Services/MessageHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices.Marshalling;
 using System.Text.Json;
 using OpenAI.GPT3.ObjectModels;
 using OpenAI.GPT3.ObjectModels.RequestModels;
@@ -54,6 +55,13 @@ public class MessageHandler
 
     private ChatMessage GenerateSystemMessage(string relevantRulesString)
     {
+        var placeholders = new
+        {
+            Email = "{{ EMAIL }}",
+            Subject = "{{ SUBJECT }}",
+            Body = "{{ BODY }}"
+        };
+
         var systemMessage = new ChatMessage(role: "system", content: string.Empty);
         systemMessage.Content = $"""
 You are SSWBot, a helpful, friendly and funny bot - with a 
@@ -70,10 +78,10 @@ Reference data based on user query: {relevantRulesString}
 Summarise the above, prioritising the most relevant information, without copying anything verbatim. 
 Use emojis, keep it humourous cool and fresh. If an email or appointment should be sent, include a 
 template in the format: 
-To: <email> 
-CC: <email> 
-Subject: <subject> 
-Body: <body> 
+To: {placeholders.Email}
+CC: {placeholders.Email}
+Subject: {placeholders.Subject}
+Body: {placeholders.Body}
     
 You should use the phrase "As per https://ssw.com.au/rules/<ruleName>" at the start of the response 
 when you are referring to data sourced from a rule above (make sure it is a URL - only include this if it is a rule name in the provided reference data) 🤓. 

--- a/src/Application/Services/MessageHandler.cs
+++ b/src/Application/Services/MessageHandler.cs
@@ -54,15 +54,8 @@ public class MessageHandler
 
     private ChatMessage GenerateSystemMessage(string relevantRulesString)
     {
-        var placeholders = new
-        {
-            Email = "{{ EMAIL }}",
-            Subject = "{{ SUBJECT }}",
-            Body = "{{ BODY }}"
-        };
-
         var systemMessage = new ChatMessage(role: "system", content: string.Empty);
-        systemMessage.Content = $"""
+        systemMessage.Content = $$$"""
 You are SSWBot, a helpful, friendly and funny bot - with a 
 penchant for emojis! 😋 You will use emojis throughout your responses. 
 You will answer the queries that users send in. Summarise all the reference 
@@ -72,15 +65,15 @@ task, make sure you give them in a numbered list. If a request suggests the user
 wants to make an action, guide them toward completing the action. For example 
 if a person is sick, they will want to take sick leave or work from home. 
     
-Reference data based on user query: {relevantRulesString} 
+Reference data based on user query: {{{relevantRulesString}}}
     
 Summarise the above, prioritising the most relevant information, without copying anything verbatim. 
 Use emojis, keep it humourous cool and fresh. If an email or appointment should be sent, include a 
-template in the format: 
-To: {placeholders.Email}
-CC: {placeholders.Email}
-Subject: {placeholders.Subject}
-Body: {placeholders.Body}
+template in the format:
+To: {{ EMAIL }}
+CC: {{ EMAIL }}
+Subject: {{ SUBJECT }}
+Body: {{ BODY }}
     
 You should use the phrase "As per https://ssw.com.au/rules/<ruleName>" at the start of the response 
 when you are referring to data sourced from a rule above (make sure it is a URL - only include this if it is a rule name in the provided reference data) 🤓. 

--- a/src/Application/Services/MessageHandler.cs
+++ b/src/Application/Services/MessageHandler.cs
@@ -1,5 +1,4 @@
 ﻿using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices.Marshalling;
 using System.Text.Json;
 using OpenAI.GPT3.ObjectModels;
 using OpenAI.GPT3.ObjectModels.RequestModels;


### PR DESCRIPTION
Closes #54 

Changed the prompt to instead recieve in the form {{ PLACEHOLDER_HERE }} like so:
![image](https://github.com/SSWConsulting/SSW.Rules.GPT/assets/20507092/aefa3ba3-59bc-4de7-b7b2-a537bf828683)
**Figure: Placeholder object**

This object was required due to the `@""` string not accepting curly braces. 

![image](https://github.com/SSWConsulting/SSW.Rules.GPT/assets/20507092/5cdea841-1a21-40cc-978c-654b7eec4ec9)
**Figure: Example 1 of the curly braces placeholder prompt adjustment**

![image](https://github.com/SSWConsulting/SSW.Rules.GPT/assets/20507092/e109cd09-331c-4bf1-991e-2ac4d2fe3b12)
**Figure: Example 2**

