### PR TITLE
Add ChatGPT Icon

### DIFF
--- a/src/WebUI/Components/RulesBotChat.razor
+++ b/src/WebUI/Components/RulesBotChat.razor
@@ -40,12 +40,15 @@
             @if (DataState.ChatMessages.Count == 0)
             {
                 <MudStack Justify="Justify.Center" AlignItems="AlignItems.Center" Style="height: 60%">
-                    <MudText Typo="Typo.h3">
-                        <b>RulesGPT</b>
-                    </MudText>
-                    <MudText Typo="Typo.subtitle1" Style="font-style: italic">
-                       Examples
-                    </MudText>
+                    <MudStack Row="true">
+                        <MudAvatar Size="Size.Large">
+                            <MudImage Src="images/chatgpt-icon.svg"></MudImage>
+                        </MudAvatar>
+                        <MudText Typo="Typo.h3">
+                            <b>RulesGPT</b>
+                        </MudText>
+                    </MudStack>
+                    <MudText Typo="Typo.subtitle1" Style="font-style: italic">Examples</MudText>
                     <MudStack Class="pt-0">
                         <MudButton Variant="Variant.Outlined" EndIcon="@Icons.Material.Filled.ArrowForward" OnClick="@(() => OnExampleClicked("How do I send a v2 email?"))">
                             How do I send a v2 email?


### PR DESCRIPTION
Closes #63 

Added a ChatGPT Logo next to the RulesGPT Title

<!-- include screenshots if relevant -->
![image](https://github.com/SSWConsulting/SSW.Rules.GPT/assets/61717342/a6de83b9-23de-41db-8c58-1cc85ab00d81)
Figure: Screenshot of change