### PR TITLE
✨New Feature - Edit and Resend a Question

### DIFF
--- a/src/WebUI/Classes/ChatLinkedList.cs
+++ b/src/WebUI/Classes/ChatLinkedList.cs
@@ -1,0 +1,66 @@
+﻿using OpenAI.GPT3.ObjectModels.RequestModels;
+
+namespace WebUI.Classes;
+
+public class ChatLinkedList : List<ChatLinkedListItem>
+{
+    public ChatLinkedListItem Add(ChatMessage message)
+    {
+        var newItem = new ChatLinkedListItem(message);
+        Add(newItem);
+        
+        return newItem;
+    }
+    
+    public ChatLinkedListItem AddAfter(ChatMessage message, ChatLinkedListItem item)
+    {
+        if (item != null && !Contains(item))
+            throw new ArgumentException("Item is not in the list");
+
+        var newItem = new ChatLinkedListItem(message, item);
+        item.Next = newItem;
+        Add(newItem);
+        
+        return newItem;        
+    }
+    
+    public ChatLinkedListItem AddRight(ChatMessage newMessage, ChatLinkedListItem item)
+    {
+        if (!Contains(item))
+            throw new ArgumentException("Item is not in the list");
+
+        var target = item;
+        
+        while (target.Right is not null)
+        {
+            target = target.Right;
+        }
+
+        var newItem = new ChatLinkedListItem(newMessage, null, target);
+        target.Right = newItem;
+        Add(newItem);
+
+        return target;
+    }
+
+    public List<ChatLinkedListItem> GetThread(ChatLinkedListItem item)
+    {
+        var head = item;
+        
+        while (item.Previous is not null)
+        {
+            head = item.Previous;
+        }
+
+        var thread = new List<ChatLinkedListItem>();
+        var target = head;
+
+        while (target is not null)
+        {
+            thread.Add(target);
+            target = target.Next;
+        }
+
+        return thread;
+    }
+}

--- a/src/WebUI/Classes/ChatLinkedList.cs
+++ b/src/WebUI/Classes/ChatLinkedList.cs
@@ -35,26 +35,45 @@ public class ChatLinkedList : List<ChatLinkedListItem>
         {
             target = target.Right;
         }
+        
+        var newItem = new ChatLinkedListItem(newMessage, item.Previous, target);
 
-        var newItem = new ChatLinkedListItem(newMessage, null, target);
+        newItem.Left = target;
         target.Right = newItem;
-        Add(newItem);
 
-        return target;
+        Add(newItem);
+        Move(item, Direction.Right);
+
+        return newItem;
+    }
+    
+    public void Move(ChatLinkedListItem item, Direction direction)
+    {
+        if (!Contains(item))
+            throw new ArgumentException("Item is not in the list");
+        
+        var target = direction == Direction.Left 
+            ? item.Left
+            : item.Right;
+
+        if (target == null)
+        {
+            return;
+        }
+
+        if (item.Previous != null)
+        {
+            item.Previous.Next = target;
+        }
     }
 
     public List<ChatLinkedListItem> GetThread(ChatLinkedListItem item)
     {
-        var head = item;
-        
-        while (item.Previous is not null)
-        {
-            head = item.Previous;
-        }
-
+        var head = GetHead(item);
         var thread = new List<ChatLinkedListItem>();
         var target = head;
 
+        //Move from top of list to bottom
         while (target is not null)
         {
             thread.Add(target);
@@ -62,5 +81,15 @@ public class ChatLinkedList : List<ChatLinkedListItem>
         }
 
         return thread;
+    }
+
+    private ChatLinkedListItem GetHead(ChatLinkedListItem item)
+    {
+        var head = item;
+        
+        while (head.Previous is not null)
+            head = head.Previous;
+
+        return head;
     }
 }

--- a/src/WebUI/Classes/ChatLinkedListItem.cs
+++ b/src/WebUI/Classes/ChatLinkedListItem.cs
@@ -1,0 +1,63 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using OpenAI.GPT3.ObjectModels.RequestModels;
+
+namespace WebUI.Classes;
+
+public class ChatLinkedListItem
+{
+    public ChatLinkedListItem(ChatMessage message)
+    {
+        Message = message;
+    }
+    
+    public ChatLinkedListItem(ChatMessage message, ChatLinkedListItem previous)
+    {
+        Message = message;
+        Previous = previous;
+    }
+    
+    public ChatLinkedListItem(ChatMessage message, ChatLinkedListItem previous, ChatLinkedListItem left)
+    {
+        Message = message;
+        Previous = previous;
+        Left = left;
+    }
+
+    public int LeftCount
+    {
+        get
+        {
+            var count = 0;
+            var left = Left;
+            while (left is not null)
+            {
+                count++;
+                left = left.Left;
+            }
+
+            return count;            
+        }
+    }
+
+    public int RightCount
+    {
+        get
+        {
+            var count = 0;
+            var right = Right;
+            while (right is not null)
+            {
+                count++;
+                right = right.Right;
+            }
+
+            return count;            
+        }
+    }
+
+    public ChatMessage Message { get; }
+    public ChatLinkedListItem? Previous { get; }
+    public ChatLinkedListItem? Next { get; set; }
+    public ChatLinkedListItem? Left { get; set; }
+    public ChatLinkedListItem? Right { get; set; }
+}

--- a/src/WebUI/Classes/ChatLinkedListItem.cs
+++ b/src/WebUI/Classes/ChatLinkedListItem.cs
@@ -16,7 +16,7 @@ public class ChatLinkedListItem
         Previous = previous;
     }
     
-    public ChatLinkedListItem(ChatMessage message, ChatLinkedListItem previous, ChatLinkedListItem left)
+    public ChatLinkedListItem(ChatMessage message, ChatLinkedListItem? previous, ChatLinkedListItem left)
     {
         Message = message;
         Previous = previous;

--- a/src/WebUI/Classes/Direction.cs
+++ b/src/WebUI/Classes/Direction.cs
@@ -1,0 +1,7 @@
+﻿namespace WebUI.Classes;
+
+public enum Direction
+{
+    Left,
+    Right
+}

--- a/src/WebUI/Components/ChatItem.razor
+++ b/src/WebUI/Components/ChatItem.razor
@@ -2,6 +2,7 @@
 @implements IDisposable
 @inject DataState DataState
 @inject NotifierService NotifierService
+@inject SswRulesGptDialogService SswRulesGptDialogService
 
 <style>
     .chat-box {
@@ -24,9 +25,15 @@
                 <MudText Typo="Typo.body1" Align="Align.Right">
                     <b>You</b>
                 </MudText>
-                <MudPaper Elevation="1" Class="px-4 py-3" Style=@(!isDarkMode ? "color: white; background: #323332;" : "")>
-                    <MudText Typo="Typo.body1">@Message.Content</MudText>
-                </MudPaper>
+                <MudStack Row="true">
+                    @if(!DataState.IsAwaitingResponse)
+                    {
+                        <MudIconButton Icon="@Icons.Material.Filled.Edit" OnClick="OnEditClicked"/>
+                    }
+                    <MudPaper Elevation="1" Class="px-4 py-3" Style=@(!isDarkMode ? "color: white; background: #323332;" : "")>
+                        <MudText Typo="Typo.body1">@Message.Content</MudText>
+                    </MudPaper>
+                </MudStack>
             </MudStack>
             <MudAvatar>
                 <MudIcon Icon="@Icons.Material.Filled.Person"></MudIcon>
@@ -63,7 +70,7 @@
 @code{
 
     [Parameter] public ChatMessage Message { get; set; }
-    [Parameter] public bool isDarkMode { get; set; }
+    [CascadingParameter] public bool isDarkMode { get; set; }
 
     private bool isUser;
 
@@ -75,9 +82,29 @@
 
     private async Task OnNotify()
     {
-        await InvokeAsync(() => { StateHasChanged(); });
+        await InvokeAsync(StateHasChanged);
     }
 
+    private async Task OnEditClicked()
+    {
+        if (Message.Content == DataState.NewMessageString)
+        {
+            return;
+        }
+        
+        if (!string.IsNullOrEmpty(DataState.NewMessageString))
+        {
+            var result = await SswRulesGptDialogService.EditMessageDialog();
+            if (!result)
+            {
+                return;
+            }   
+        }
+
+        DataState.NewMessageString = Message.Content;
+        _= NotifierService.Update();
+    }
+    
     public void Dispose()
     {
         NotifierService.Notify -= OnNotify;

--- a/src/WebUI/Components/ChatItem.razor
+++ b/src/WebUI/Components/ChatItem.razor
@@ -53,7 +53,7 @@
                             }
                             else
                             {
-                                <MudText Typo="Typo.body1">@MessageThreadItem.Message.Content</MudText>
+                                <MudText Style="white-space: pre-wrap" Typo="Typo.body1">@MessageThreadItem.Message.Content</MudText>
                             }
                         </MudPaper>
                     </MudStack>

--- a/src/WebUI/Components/ChatItem.razor
+++ b/src/WebUI/Components/ChatItem.razor
@@ -1,4 +1,6 @@
 ﻿@using OpenAI.GPT3.ObjectModels.RequestModels
+@using WebUI.Classes
+@using Direction = WebUI.Classes.Direction
 @implements IDisposable
 @inject DataState DataState
 @inject NotifierService NotifierService
@@ -30,13 +32,47 @@
                         @if (!DataState.IsAwaitingResponse)
                         {
                             <div class="edit-button">
-                                <MudIconButton Class="edit-button" Icon="@Icons.Material.Filled.Edit" OnClick="OnEditClicked"/>
+                                <MudIconButton Class="edit-button" Icon="@Icons.Material.Filled.Edit" OnClick="(() => SetEditState(true))"/>
                             </div>
                         }
+                        else
+                        {
+                            <MudSpacer/>
+                        }
                         <MudPaper Elevation="1" Class="px-4 py-3" Style=@(!isDarkMode ? "color: white; background: #323332;" : "")>
-                            <MudText Typo="Typo.body1">@Message.Content</MudText>
+                            @if (isEditing)
+                            {
+                                <MudStack>
+                                    <MultilineInput @ref="multilineInput" Data="@MessageThreadItem.Message.Content" OnSubmitted="SubmitEdit"/>
+                                    <MudStack Row="true" Spacing="1">
+                                        <MudIconButton Size="Size.Small" Color="Color.Success" Icon="@Icons.Material.Filled.Done" OnClick="OnEditDoneClicked"/>
+                                        <MudIconButton Size="Size.Small" Color="Color.Error" Icon="@Icons.Material.Filled.Cancel" OnClick="(() => SetEditState(false))"/>
+                                        <MudSpacer/>
+                                    </MudStack>
+                                </MudStack>
+                            }
+                            else
+                            {
+                                <MudText Typo="Typo.body1">@MessageThreadItem.Message.Content</MudText>
+                            }
                         </MudPaper>
                     </MudStack>
+                    @if (MessageThreadItem.LeftCount + MessageThreadItem.RightCount > 0)
+                    {
+                        var total = MessageThreadItem.LeftCount + MessageThreadItem.RightCount + 1;
+                        var position = MessageThreadItem.LeftCount + 1;
+
+                        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                            <MudSpacer/>
+                            <MudIconButton Icon="@Icons.Material.Rounded.ChevronLeft" Size="Size.Small" Disabled="@(position == 1)" OnClick="(() => OnMoveClicked(Direction.Left))"/>
+                            <MudText>
+                                @position
+                                <span style="color: #BDBDBD">/</span>
+                                @total
+                            </MudText>
+                            <MudIconButton Icon="@Icons.Material.Rounded.ChevronRight" Size="Size.Small" Disabled="@(position == total)" OnClick="(() => OnMoveClicked(Direction.Right))"/>
+                        </MudStack>
+                    }
                 </MudStack>
                 <MudAvatar>
                     <MudIcon Icon="@Icons.Material.Filled.Person"></MudIcon>
@@ -46,7 +82,7 @@
     }
     else
     {
-        <MudStack Class=@(DataState.IsAwaitingResponse && DataState.CurrentMessageThread.Last().Message == Message ? "mb-12 mx-4" : "mx-4") Row="true">
+        <MudStack Class=@(DataState.IsAwaitingResponse && DataState.CurrentMessageThread.Last().Message == MessageThreadItem.Message ? "mb-12 mx-4" : "mx-4") Row="true">
             <MudAvatar>
                 <MudImage Src="images/chatgpt-icon.svg"></MudImage>
             </MudAvatar>
@@ -54,7 +90,7 @@
                 <MudText Typo="Typo.body1">
                     <b>RulesGPT</b>
                 </MudText>
-                @if (DataState.IsAwaitingResponseStream && string.IsNullOrWhiteSpace(Message.Content))
+                @if (DataState.IsAwaitingResponseStream && string.IsNullOrWhiteSpace(MessageThreadItem.Message.Content))
                 {
                     <MudPaper Elevation="1" Class="px-4 py-3" Style="text-align: center;">
                         <MudProgressCircular Size="Size.Small" Color="Color.Secondary" Indeterminate="true" Style="vertical-align: bottom;"/>
@@ -63,7 +99,7 @@
                 else
                 {
                     <MudPaper Elevation="1" Class="px-4 py-3" Style=@(isDarkMode ? "color: white;" : "")>
-                        <Markdown Content=@Message.Content/>
+                        <Markdown Content=@MessageThreadItem.Message.Content/>
                     </MudPaper>
                 }
             </MudStack>
@@ -72,16 +108,20 @@
 </MudListItem>
 
 @code{
-
-    [Parameter] public ChatMessage Message { get; set; }
     [CascadingParameter] public bool isDarkMode { get; set; }
 
+    [Parameter] public ChatLinkedListItem MessageThreadItem { get; set; } = default!;
+    [Parameter] public EventCallback<(ChatLinkedListItem, string)> OnEditSubmittedEvent { get; set; }
+    [Parameter] public EventCallback<(ChatLinkedListItem, Direction)> OnMoveClickedEvent { get; set; }
+
     private bool isUser;
+    private bool isEditing;
+    private MultilineInput multilineInput;
 
     protected override async Task OnInitializedAsync()
     {
         NotifierService.Notify += OnNotify;
-        isUser = Message.Role == "user";
+        isUser = MessageThreadItem.Message.Role == "user";
     }
 
     private async Task OnNotify()
@@ -89,24 +129,33 @@
         await InvokeAsync(StateHasChanged);
     }
 
-    private async Task OnEditClicked()
+    private async Task SetEditState(bool editing)
     {
-        if (Message.Content == DataState.NewMessageString)
+        isEditing = editing;
+        StateHasChanged();
+    }
+
+    private async Task OnEditDoneClicked()
+    {
+        await multilineInput.Submit();
+    }
+
+    private async Task SubmitEdit(string message)
+    {
+        isEditing = false;
+        
+        if (message == MessageThreadItem.Message.Content)
         {
             return;
         }
-
-        if (!string.IsNullOrEmpty(DataState.NewMessageString))
-        {
-            var result = await SswRulesGptDialogService.EditMessageDialog();
-            if (!result)
-            {
-                return;
-            }
-        }
-
-        DataState.NewMessageString = Message.Content;
-        _ = NotifierService.Update();
+        
+        await OnEditSubmittedEvent.InvokeAsync((MessageThreadItem, message));
+        //StateHasChanged();
+    }
+    
+    private async Task OnMoveClicked(Direction direction)
+    {
+        await OnMoveClickedEvent.InvokeAsync((MessageThreadItem, direction));
     }
 
     public void Dispose()

--- a/src/WebUI/Components/ChatItem.razor
+++ b/src/WebUI/Components/ChatItem.razor
@@ -1,0 +1,85 @@
+﻿@using OpenAI.GPT3.ObjectModels.RequestModels
+@implements IDisposable
+@inject DataState DataState
+@inject NotifierService NotifierService
+
+<style>
+    .chat-box {
+        max-width: 70%;
+    }
+
+    @@media screen and (max-width: 600px) {
+        .chat-box {
+            max-width: 85%;
+        }
+    }
+</style>
+
+<MudListItem>
+    @if (isUser)
+    {
+        <MudStack Class="mx-4" Row="true">
+            <MudSpacer/>
+            <MudStack Spacing="1" Class="chat-box">
+                <MudText Typo="Typo.body1" Align="Align.Right">
+                    <b>You</b>
+                </MudText>
+                <MudPaper Elevation="1" Class="px-4 py-3" Style=@(!isDarkMode ? "color: white; background: #323332;" : "")>
+                    <MudText Typo="Typo.body1">@Message.Content</MudText>
+                </MudPaper>
+            </MudStack>
+            <MudAvatar>
+                <MudIcon Icon="@Icons.Material.Filled.Person"></MudIcon>
+            </MudAvatar>
+        </MudStack>
+    }
+    else
+    {
+        <MudStack Class=@(DataState.IsAwaitingResponse && DataState.ChatMessages.Last() == Message ? "mb-12 mx-4" : "mx-4") Row="true">
+            <MudAvatar>
+                <MudImage Src="images/chatgpt-icon.svg"></MudImage>
+            </MudAvatar>
+            <MudStack Spacing="1" Class="chat-box">
+                <MudText Typo="Typo.body1">
+                    <b>RulesGPT</b>
+                </MudText>
+                @if (DataState.IsAwaitingResponseStream && string.IsNullOrWhiteSpace(Message.Content))
+                {
+                    <MudPaper Elevation="1" Class="px-4 py-3" Style="text-align: center;">
+                        <MudProgressCircular Size="Size.Small" Color="Color.Secondary" Indeterminate="true" Style="vertical-align: bottom;"/>
+                    </MudPaper>
+                }
+                else
+                {
+                    <MudPaper Elevation="1" Class="px-4 py-3" Style=@(isDarkMode ? "color: white;" : "")>
+                        <Markdown Content=@Message.Content/>
+                    </MudPaper>
+                }
+            </MudStack>
+        </MudStack>
+    }
+</MudListItem>
+
+@code{
+
+    [Parameter] public ChatMessage Message { get; set; }
+    [Parameter] public bool isDarkMode { get; set; }
+
+    private bool isUser;
+
+    protected override async Task OnInitializedAsync()
+    {
+        NotifierService.Notify += OnNotify;
+        isUser = Message.Role == "user";
+    }
+
+    private async Task OnNotify()
+    {
+        await InvokeAsync(() => { StateHasChanged(); });
+    }
+
+    public void Dispose()
+    {
+        NotifierService.Notify -= OnNotify;
+    }
+}

--- a/src/WebUI/Components/ChatItem.razor
+++ b/src/WebUI/Components/ChatItem.razor
@@ -19,30 +19,34 @@
 <MudListItem>
     @if (isUser)
     {
-        <MudStack Class="mx-4" Row="true">
-            <MudSpacer/>
-            <MudStack Spacing="1" Class="chat-box">
-                <MudText Typo="Typo.body1" Align="Align.Right">
-                    <b>You</b>
-                </MudText>
-                <MudStack Row="true">
-                    @if(!DataState.IsAwaitingResponse)
-                    {
-                        <MudIconButton Icon="@Icons.Material.Filled.Edit" OnClick="OnEditClicked"/>
-                    }
-                    <MudPaper Elevation="1" Class="px-4 py-3" Style=@(!isDarkMode ? "color: white; background: #323332;" : "")>
-                        <MudText Typo="Typo.body1">@Message.Content</MudText>
-                    </MudPaper>
+        <div class="item-root">
+            <MudStack Class="mx-4" Row="true">
+                <MudSpacer/>
+                <MudStack Spacing="1" Class="chat-box">
+                    <MudText Typo="Typo.body1" Align="Align.Right">
+                        <b>You</b>
+                    </MudText>
+                    <MudStack Row="true">
+                        @if (!DataState.IsAwaitingResponse)
+                        {
+                            <div class="edit-button">
+                                <MudIconButton Class="edit-button" Icon="@Icons.Material.Filled.Edit" OnClick="OnEditClicked"/>
+                            </div>
+                        }
+                        <MudPaper Elevation="1" Class="px-4 py-3" Style=@(!isDarkMode ? "color: white; background: #323332;" : "")>
+                            <MudText Typo="Typo.body1">@Message.Content</MudText>
+                        </MudPaper>
+                    </MudStack>
                 </MudStack>
+                <MudAvatar>
+                    <MudIcon Icon="@Icons.Material.Filled.Person"></MudIcon>
+                </MudAvatar>
             </MudStack>
-            <MudAvatar>
-                <MudIcon Icon="@Icons.Material.Filled.Person"></MudIcon>
-            </MudAvatar>
-        </MudStack>
+        </div>
     }
     else
     {
-        <MudStack Class=@(DataState.IsAwaitingResponse && DataState.ChatMessages.Last() == Message ? "mb-12 mx-4" : "mx-4") Row="true">
+        <MudStack Class=@(DataState.IsAwaitingResponse && DataState.CurrentMessageThread.Last().Message == Message ? "mb-12 mx-4" : "mx-4") Row="true">
             <MudAvatar>
                 <MudImage Src="images/chatgpt-icon.svg"></MudImage>
             </MudAvatar>
@@ -91,20 +95,20 @@
         {
             return;
         }
-        
+
         if (!string.IsNullOrEmpty(DataState.NewMessageString))
         {
             var result = await SswRulesGptDialogService.EditMessageDialog();
             if (!result)
             {
                 return;
-            }   
+            }
         }
 
         DataState.NewMessageString = Message.Content;
-        _= NotifierService.Update();
+        _ = NotifierService.Update();
     }
-    
+
     public void Dispose()
     {
         NotifierService.Notify -= OnNotify;

--- a/src/WebUI/Components/ChatItem.razor.css
+++ b/src/WebUI/Components/ChatItem.razor.css
@@ -1,0 +1,8 @@
+﻿.edit-button {
+    opacity: 0;
+    transition: 0.5s ease-in-out;
+}
+
+.item-root:hover .edit-button {
+    opacity: 1;
+}

--- a/src/WebUI/Components/EditMessageDialog.razor
+++ b/src/WebUI/Components/EditMessageDialog.razor
@@ -1,0 +1,16 @@
+﻿<MudDialog>
+    <DialogContent>
+        This action will delete your unsent message.
+    </DialogContent>
+    <DialogActions>
+        <MudButton OnClick="Cancel">Cancel</MudButton>
+        <MudButton Color="Color.Error" OnClick="Submit">Ok</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] MudDialogInstance MudDialog { get; set; }
+    
+    void Submit() => MudDialog.Close(DialogResult.Ok(true));
+    void Cancel() => MudDialog.Cancel();
+}

--- a/src/WebUI/Components/MultilineInput.razor
+++ b/src/WebUI/Components/MultilineInput.razor
@@ -1,5 +1,5 @@
-﻿<div class="container">
-    <textarea @oninput="HandleInput" @onkeydown="HandleSubmit">@message</textarea>     
+﻿<div class="container" data-replicated-value="@message">
+    <textarea rows="1" @oninput="HandleInput" @onkeydown="HandleSubmit">@message</textarea>     
 </div>
 
 @code {

--- a/src/WebUI/Components/MultilineInput.razor
+++ b/src/WebUI/Components/MultilineInput.razor
@@ -1,0 +1,34 @@
+﻿<div class="container">
+    <textarea @oninput="HandleInput" @onkeydown="HandleSubmit">@message</textarea>     
+</div>
+
+@code {
+    [Parameter] public string Data { get; set; } = default!;
+    [Parameter] public EventCallback<string> OnSubmitted { get; set; }
+    
+    private string message = "";
+
+    public async Task Submit()
+    {
+        await OnSubmitted.InvokeAsync(message);
+    }
+
+    protected override void OnParametersSet()
+    {
+        message = Data;
+        base.OnParametersSet();
+    }
+
+    private async Task HandleInput(ChangeEventArgs args)
+    {
+        message = args.Value.ToString();
+    }
+    
+    private async Task HandleSubmit(KeyboardEventArgs args)
+    {
+        if (args is { Key: "Enter", ShiftKey: false })
+        {
+            await OnSubmitted.InvokeAsync(message);
+        }
+    }
+}

--- a/src/WebUI/Components/MultilineInput.razor.css
+++ b/src/WebUI/Components/MultilineInput.razor.css
@@ -1,0 +1,37 @@
+﻿.container {
+    display: grid;
+}
+
+.container:after {
+    content: attr(data-replicated-value) " ";
+    white-space: pre-wrap;
+    visibility: hidden;
+}
+
+.container > textarea {
+    resize: none;
+    overflow: hidden;
+}
+
+.container > textarea, .container:after {
+    /* Style the textarea here, it must have the same styling as the .container:after to autoscale properly */
+    background: none;
+    color: inherit;
+    font: inherit;
+    
+    border: 1px solid #a3a3a3;
+    border-radius: 5px;
+    padding: 0.5rem;
+    
+    transition: border-color 0.4s ease-in-out;
+    
+    grid-area: 1 / 1 / 2 / 2;
+}
+
+.container > textarea:hover, 
+.container > textarea:focus,
+.container > textarea:hover .container:after,
+.container > textarea:focus .container:after {
+    outline: none;
+    border-color: #dadada;
+}

--- a/src/WebUI/Components/RulesBotChat.razor
+++ b/src/WebUI/Components/RulesBotChat.razor
@@ -33,9 +33,9 @@
             else
             {
                 <MudList Class="py-0 chatContainer" DisableGutters="true">
-                    @foreach (var message in DataState.CurrentMessageThread.Where(s => s.Message.Role != "system").Select(s => s.Message))
+                    @foreach (var message in DataState.CurrentMessageThread.Where(s => s.Message.Role != "system"))
                     {
-                        <ChatItem Message="message" />
+                        <ChatItem MessageThreadItem="message" OnMoveClickedEvent="Move" OnEditSubmittedEvent="SendEditedMessage"/>
                     }
                 </MudList>
             }

--- a/src/WebUI/Components/RulesBotChat.razor
+++ b/src/WebUI/Components/RulesBotChat.razor
@@ -42,7 +42,7 @@
                 <MudList Class="py-0 chatContainer" DisableGutters="true">
                     @foreach (var message in DataState.ChatMessages.Where(s => s.Role != "system"))
                     {
-                        <ChatItem Message="message" isDarkMode="isDarkMode"/>
+                        <ChatItem Message="message" />
                     }
                 </MudList>
             }
@@ -52,24 +52,18 @@
         </MudPopover>
     </MudPaper>
     <MudStack Row="true" Class="mt-3">
-        <MudTextField Style="height: 100%;" Clearable="true" Disabled="DataState.IsAwaitingResponse" Class="mt-0" @bind-Value="NewMessageString" OnKeyDown="MessageTextFieldHandleEnterKey" Immediate="true" Label="Ask a question!" Variant="Variant.Outlined"></MudTextField>
+        <MudTextField Style="height: 100%;" Clearable="true" Disabled="DataState.IsAwaitingResponse" Class="mt-0" @bind-Value="DataState.NewMessageString" OnKeyDown="MessageTextFieldHandleEnterKey" Immediate="true" Label="Ask a question!" Variant="Variant.Outlined"></MudTextField>
         <MudButton Color="Color.Secondary" Variant="Variant.Filled" OnClick="SendMessage">
             <MudIcon Icon="@Icons.Material.Filled.Send"></MudIcon>
         </MudButton>
     </MudStack>
 </div>
 
-
 @code {
 
-    [CascadingParameter]
-    protected MudTheme Theme { get; set; }
-
-    [CascadingParameter]
-    protected bool isDarkMode { get; set; }
-
-    public string NewMessageString { get; set; } = string.Empty;
-
+    [CascadingParameter] protected MudTheme Theme { get; set; }
+    [CascadingParameter] protected bool isDarkMode { get; set; }
+    
     protected override async Task OnInitializedAsync()
     {
         NotifierService.Notify += OnNotify;
@@ -81,13 +75,13 @@
 
     private async Task OnExampleClicked(string message)
     {
-        NewMessageString = message;
+        DataState.NewMessageString = message;
         await SendMessage();
     }
 
     public async Task SendMessage()
     {
-        if (string.IsNullOrWhiteSpace(NewMessageString))
+        if (string.IsNullOrWhiteSpace(DataState.NewMessageString))
         {
             return;
         }
@@ -105,10 +99,10 @@
             }
         }
 
-        _ = Analytics.TrackEvent("SendMessage", new { message = NewMessageString, ownKey = DataState.OpenAiApiKey != null });
+        _ = Analytics.TrackEvent("SendMessage", new { message = DataState.NewMessageString, ownKey = DataState.OpenAiApiKey != null });
 
-        var newChatMessage = new ChatMessage("user", NewMessageString);
-        NewMessageString = string.Empty;
+        var newChatMessage = new ChatMessage("user", DataState.NewMessageString);
+        DataState.NewMessageString = string.Empty;
         DataState.ChatMessages.Add(newChatMessage);
 
         var newAssistantMessage = new ChatMessage("assistant", string.Empty);

--- a/src/WebUI/Components/RulesBotChat.razor
+++ b/src/WebUI/Components/RulesBotChat.razor
@@ -33,7 +33,7 @@
             else
             {
                 <MudList Class="py-0 chatContainer" DisableGutters="true">
-                    @foreach (var message in DataState.ChatMessages.Where(s => s.Message.Role != "system"))
+                    @foreach (var message in DataState.CurrentMessageThread.Where(s => s.Message.Role != "system").Select(s => s.Message))
                     {
                         <ChatItem Message="message" />
                     }

--- a/src/WebUI/Components/RulesBotChat.razor
+++ b/src/WebUI/Components/RulesBotChat.razor
@@ -1,13 +1,6 @@
 @using OpenAI.GPT3.ObjectModels.RequestModels
-@implements IDisposable
-@inject DataState DataState
-@inject SswRulesGptDialogService SswRulesGptDialogService
-@inject ApiKeyValidationService ApiKeyValidationService
-@inject NotifierService NotifierService
-@inject SignalRClient SignalR
-@inject IJSRuntime Js
-@inject ISnackbar Snackbar
-@inject IAnalytics Analytics
+
+@inherits RulesBotChatBase
 
 <div style="display: grid; grid-template-rows: 1fr auto; height: 100%; padding: 24px 0;">
     <MudPaper Elevation="0" Style=@($"background: {(!isDarkMode ? Theme.Palette.BackgroundGrey : Theme.PaletteDark.BackgroundGrey)}; border: 1px solid #e6e6e6; overflow-y: auto; height: 100%")>
@@ -40,7 +33,7 @@
             else
             {
                 <MudList Class="py-0 chatContainer" DisableGutters="true">
-                    @foreach (var message in DataState.ChatMessages.Where(s => s.Role != "system"))
+                    @foreach (var message in DataState.ChatMessages.Where(s => s.Message.Role != "system"))
                     {
                         <ChatItem Message="message" />
                     }
@@ -58,126 +51,3 @@
         </MudButton>
     </MudStack>
 </div>
-
-@code {
-
-    [CascadingParameter] protected MudTheme Theme { get; set; }
-    [CascadingParameter] protected bool isDarkMode { get; set; }
-    
-    protected override async Task OnInitializedAsync()
-    {
-        NotifierService.Notify += OnNotify;
-        NotifierService.CancelMessageStreamEvent += OnCancelMessageStream;
-    // Only for use when styling
-    //DataState.ChatMessages.Add(new ChatMessage("user", "Hello, I'm a user"));
-    //DataState.ChatMessages.Add(new ChatMessage("assistant", "1. hello there https://ssw.com.au \r\n 2. hello there \r\n \r\n How are you? \r\n Things are going well \r\n * hi there \r\n * how are you doing? \r\n \r\n | Tables | Are | Cool | \r\n | ------------- | :-----------: | -----: | \r\n | col 3 is | right-aligned | $1600 | \r\n | col 2 is | centered | $12 | \r\n | zebra stripes | are neat | $1 |"));
-    }
-
-    private async Task OnExampleClicked(string message)
-    {
-        DataState.NewMessageString = message;
-        await SendMessage();
-    }
-
-    public async Task SendMessage()
-    {
-        if (string.IsNullOrWhiteSpace(DataState.NewMessageString))
-        {
-            return;
-        }
-
-        if (SignalR.GetConnectionState() == SignalRClient.StatusHubConnectionState.Disconnected)
-        {
-            try
-            {
-                await SignalR.StartAsync(DataState.CancellationTokenSource.Token);
-            }
-            catch (HttpRequestException e)
-            {
-                Snackbar.Add("Unable to connect to SSW RulesGPT", Severity.Error);
-                return;
-            }
-        }
-
-        _ = Analytics.TrackEvent("SendMessage", new { message = DataState.NewMessageString, ownKey = DataState.OpenAiApiKey != null });
-
-        var newChatMessage = new ChatMessage("user", DataState.NewMessageString);
-        DataState.NewMessageString = string.Empty;
-        DataState.ChatMessages.Add(newChatMessage);
-
-        var newAssistantMessage = new ChatMessage("assistant", string.Empty);
-
-        DataState.ChatMessages.Add(newAssistantMessage);
-        DataState.IsAwaitingResponseStream = true;
-        DataState.IsAwaitingResponse = true;
-        StateHasChanged();
-
-        await JsScrollMessageListToBottom();
-
-        var resultStream = SignalR.RequestNewCompletionMessage(
-            DataState.ChatMessages,
-            DataState.OpenAiApiKey,
-            DataState.SelectedGptModel,
-            DataState.CancellationTokenSource.Token);
-
-        await JsScrollMessageListToBottom();
-        await foreach (var result in resultStream.WithCancellation(DataState.CancellationTokenSource.Token))
-        {
-            DataState.IsAwaitingResponseStream = false;
-            newAssistantMessage.Content += result?.Content;
-
-            StateHasChanged();
-            _= NotifierService.Update();
-            await Js.InvokeVoidAsync("highlightCode");
-            await JsScrollMessageListToBottom();
-        }
-        DataState.IsAwaitingResponseStream = false;
-        DataState.IsAwaitingResponse = false;
-        DataState.CancellationTokenSource.Dispose();
-        DataState.CancellationTokenSource = new CancellationTokenSource();
-    }
-
-    async Task MessageTextFieldHandleEnterKey(KeyboardEventArgs args)
-    {
-        if (args is { Key: "Enter", ShiftKey: false })
-        {
-            await SendMessage();
-        }
-    }
-
-    public async Task OnNotify()
-    {
-        await InvokeAsync(() => { StateHasChanged(); });
-    }
-
-    public async Task OnCancelMessageStream()
-    {
-        await InvokeAsync(() => { CancelStreamingResponse(); });
-    }
-    
-    public void Dispose()
-    {
-        NotifierService.Notify -= OnNotify;
-        NotifierService.CancelMessageStreamEvent -= OnCancelMessageStream;
-    }
-
-    private async Task JsScrollMessageListToBottom()
-    {
-        await Js.InvokeVoidAsync("scrollLatestMessageIntoView");
-    }
-
-    private async Task CancelStreamingResponse()
-    {
-        DataState.CancellationTokenSource.Cancel();
-        DataState.CancellationTokenSource.Dispose();
-        var lastAssistantMessage = DataState.ChatMessages.LastOrDefault(s => s.Role == "assistant");
-        if (lastAssistantMessage is not null && string.IsNullOrWhiteSpace(lastAssistantMessage?.Content))
-        {
-            DataState.ChatMessages.Remove(lastAssistantMessage);
-        }
-        DataState.IsAwaitingResponse = false;
-        DataState.IsAwaitingResponseStream = false;
-        DataState.CancellationTokenSource = new CancellationTokenSource();
-    }
-
-}

--- a/src/WebUI/Components/RulesBotChat.razor
+++ b/src/WebUI/Components/RulesBotChat.razor
@@ -1,4 +1,5 @@
 @using OpenAI.GPT3.ObjectModels.RequestModels
+@implements IDisposable
 @inject DataState DataState
 @inject SswRulesGptDialogService SswRulesGptDialogService
 @inject ApiKeyValidationService ApiKeyValidationService
@@ -7,18 +8,6 @@
 @inject IJSRuntime Js
 @inject ISnackbar Snackbar
 @inject IAnalytics Analytics
-
-<style>
-    .chat-box {
-        max-width: 70%;
-    }
-
-    @@media screen and (max-width: 600px) {
-        .chat-box {
-            max-width: 85%;
-        }
-    }
-</style>
 
 <div style="display: grid; grid-template-rows: 1fr auto; height: 100%; padding: 24px 0;">
     <MudPaper Elevation="0" Style=@($"background: {(!isDarkMode ? Theme.Palette.BackgroundGrey : Theme.PaletteDark.BackgroundGrey)}; border: 1px solid #e6e6e6; overflow-y: auto; height: 100%")>
@@ -51,59 +40,19 @@
             else
             {
                 <MudList Class="py-0 chatContainer" DisableGutters="true">
-                @foreach (var message in DataState.ChatMessages.Where(s => s.Role != "system"))
-                {
-                    var isUser = message.Role == "user";
-                    <MudListItem>
-                        @if (isUser)
-                        {
-                            <MudStack Class="mx-4" Row="true">
-                                <MudSpacer/>
-                                <MudStack Spacing="1" Class="chat-box">
-                                    <MudText Typo="Typo.body1" Align="Align.Right"><b>You</b></MudText>
-                                    <MudPaper Elevation="1" Class="px-4 py-3" Style=@(!isDarkMode ? "color: white; background: #323332;" : "")>
-                                        <MudText Typo="Typo.body1">@message.Content</MudText>
-                                    </MudPaper>
-                                </MudStack>
-                                <MudAvatar>
-                                    <MudIcon Icon="@Icons.Material.Filled.Person"></MudIcon>
-                                </MudAvatar>
-                            </MudStack>
-                        }
-                        else
-                        {
-                            <MudStack Class=@(IsAwaitingResponse && DataState.ChatMessages.Last() == message ? "mb-12 mt-4 mx-4" : "mx-4") Row="true">
-                                <MudAvatar>
-                                    <MudImage Src="images/chatgpt-icon.svg"></MudImage>
-                                </MudAvatar>
-                                <MudStack Spacing="1" Class="chat-box">
-                                    <MudText Typo="Typo.body1"><b>RulesGPT</b></MudText>
-                                        @if (IsAwaitingResponseStream && string.IsNullOrWhiteSpace(message.Content))
-                                        {
-                                            <MudPaper Elevation="1" Class="px-4 py-3" Style="text-align: center;">
-                                                <MudProgressCircular Size="Size.Small" Color="Color.Secondary" Indeterminate="true" Style="vertical-align: bottom;"/>
-                                            </MudPaper>             
-                                        }
-                                        else
-                                        {
-                                            <MudPaper Elevation="1" Class="px-4 py-3" Style=@(isDarkMode ? "color: white;" : "")>
-                                                <Markdown Content=@message.Content/>
-                                            </MudPaper>
-                                        }
-                                    </MudStack>
-                                </MudStack>
-                            }
-                        </MudListItem>
+                    @foreach (var message in DataState.ChatMessages.Where(s => s.Role != "system"))
+                    {
+                        <ChatItem Message="message" isDarkMode="isDarkMode"/>
                     }
                 </MudList>
             }
         </MudContainer>
-        <MudPopover Open="IsAwaitingResponse" OverflowBehavior="OverflowBehavior.FlipNever" AnchorOrigin="Origin.BottomCenter" TransformOrigin="Origin.BottomCenter" Paper="false">
-                <MudButton Class="mb-3" OnClick="CancelStreamingResponse" Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Cancel" Color="Color.Primary">Cancel Request</MudButton>
-        	</MudPopover>
+        <MudPopover Open="DataState.IsAwaitingResponse" OverflowBehavior="OverflowBehavior.FlipNever" AnchorOrigin="Origin.BottomCenter" TransformOrigin="Origin.BottomCenter" Paper="false">
+            <MudButton Class="mb-3" OnClick="CancelStreamingResponse" Variant="Variant.Filled" StartIcon="@Icons.Material.Filled.Cancel" Color="Color.Primary">Cancel Request</MudButton>
+        </MudPopover>
     </MudPaper>
     <MudStack Row="true" Class="mt-3">
-        <MudTextField Style="height: 100%;" Clearable="true" Disabled="IsAwaitingResponse" Class="mt-0" @bind-Value="NewMessageString" OnKeyDown="MessageTextFieldHandleEnterKey" Immediate="true" Label="Ask a question!" Variant="Variant.Outlined"></MudTextField>
+        <MudTextField Style="height: 100%;" Clearable="true" Disabled="DataState.IsAwaitingResponse" Class="mt-0" @bind-Value="NewMessageString" OnKeyDown="MessageTextFieldHandleEnterKey" Immediate="true" Label="Ask a question!" Variant="Variant.Outlined"></MudTextField>
         <MudButton Color="Color.Secondary" Variant="Variant.Filled" OnClick="SendMessage">
             <MudIcon Icon="@Icons.Material.Filled.Send"></MudIcon>
         </MudButton>
@@ -112,20 +61,22 @@
 
 
 @code {
-    [CascadingParameter] protected MudTheme Theme { get; set; } 
-    [CascadingParameter] protected bool isDarkMode { get; set; }
-    
+
+    [CascadingParameter]
+    protected MudTheme Theme { get; set; }
+
+    [CascadingParameter]
+    protected bool isDarkMode { get; set; }
+
     public string NewMessageString { get; set; } = string.Empty;
-    public bool IsAwaitingResponseStream { get; set; } = false;
-    private bool IsAwaitingResponse { get; set; } = false;
 
     protected override async Task OnInitializedAsync()
     {
         NotifierService.Notify += OnNotify;
         NotifierService.CancelMessageStreamEvent += OnCancelMessageStream;
-        // Only for use when styling
-        //DataState.ChatMessages.Add(new ChatMessage("user", "Hello, I'm a user"));
-        //DataState.ChatMessages.Add(new ChatMessage("assistant", "1. hello there https://ssw.com.au \r\n 2. hello there \r\n \r\n How are you? \r\n Things are going well \r\n * hi there \r\n * how are you doing? \r\n \r\n | Tables | Are | Cool | \r\n | ------------- | :-----------: | -----: | \r\n | col 3 is | right-aligned | $1600 | \r\n | col 2 is | centered | $12 | \r\n | zebra stripes | are neat | $1 |"));
+    // Only for use when styling
+    //DataState.ChatMessages.Add(new ChatMessage("user", "Hello, I'm a user"));
+    //DataState.ChatMessages.Add(new ChatMessage("assistant", "1. hello there https://ssw.com.au \r\n 2. hello there \r\n \r\n How are you? \r\n Things are going well \r\n * hi there \r\n * how are you doing? \r\n \r\n | Tables | Are | Cool | \r\n | ------------- | :-----------: | -----: | \r\n | col 3 is | right-aligned | $1600 | \r\n | col 2 is | centered | $12 | \r\n | zebra stripes | are neat | $1 |"));
     }
 
     private async Task OnExampleClicked(string message)
@@ -140,7 +91,7 @@
         {
             return;
         }
-        
+
         if (SignalR.GetConnectionState() == SignalRClient.StatusHubConnectionState.Disconnected)
         {
             try
@@ -154,8 +105,8 @@
             }
         }
 
-        _= Analytics.TrackEvent("SendMessage", new { message = NewMessageString, ownKey = DataState.OpenAiApiKey != null });
-        
+        _ = Analytics.TrackEvent("SendMessage", new { message = NewMessageString, ownKey = DataState.OpenAiApiKey != null });
+
         var newChatMessage = new ChatMessage("user", NewMessageString);
         NewMessageString = string.Empty;
         DataState.ChatMessages.Add(newChatMessage);
@@ -163,31 +114,31 @@
         var newAssistantMessage = new ChatMessage("assistant", string.Empty);
 
         DataState.ChatMessages.Add(newAssistantMessage);
-        IsAwaitingResponseStream = true;
-        IsAwaitingResponse = true;
+        DataState.IsAwaitingResponseStream = true;
+        DataState.IsAwaitingResponse = true;
         StateHasChanged();
 
-        
         await JsScrollMessageListToBottom();
 
         var resultStream = SignalR.RequestNewCompletionMessage(
             DataState.ChatMessages,
             DataState.OpenAiApiKey,
             DataState.SelectedGptModel,
-            DataState.CancellationTokenSource.Token );
-        
+            DataState.CancellationTokenSource.Token);
+
         await JsScrollMessageListToBottom();
         await foreach (var result in resultStream.WithCancellation(DataState.CancellationTokenSource.Token))
         {
-            IsAwaitingResponseStream = false;
+            DataState.IsAwaitingResponseStream = false;
             newAssistantMessage.Content += result?.Content;
-            
+
             StateHasChanged();
+            _= NotifierService.Update();
             await Js.InvokeVoidAsync("highlightCode");
             await JsScrollMessageListToBottom();
         }
-        IsAwaitingResponseStream = false;
-        IsAwaitingResponse = false;
+        DataState.IsAwaitingResponseStream = false;
+        DataState.IsAwaitingResponse = false;
         DataState.CancellationTokenSource.Dispose();
         DataState.CancellationTokenSource = new CancellationTokenSource();
     }
@@ -202,31 +153,25 @@
 
     public async Task OnNotify()
     {
-        await InvokeAsync(() =>
-        {
-            StateHasChanged();
-        });
-    }
-    
-    public async Task OnCancelMessageStream()
-    {
-        await InvokeAsync(() =>
-        {
-            CancelStreamingResponse();
-        });
+        await InvokeAsync(() => { StateHasChanged(); });
     }
 
+    public async Task OnCancelMessageStream()
+    {
+        await InvokeAsync(() => { CancelStreamingResponse(); });
+    }
+    
     public void Dispose()
     {
         NotifierService.Notify -= OnNotify;
         NotifierService.CancelMessageStreamEvent -= OnCancelMessageStream;
     }
-    
+
     private async Task JsScrollMessageListToBottom()
     {
         await Js.InvokeVoidAsync("scrollLatestMessageIntoView");
     }
-    
+
     private async Task CancelStreamingResponse()
     {
         DataState.CancellationTokenSource.Cancel();
@@ -236,8 +181,9 @@
         {
             DataState.ChatMessages.Remove(lastAssistantMessage);
         }
-        IsAwaitingResponse = false;
-        IsAwaitingResponseStream = false;
+        DataState.IsAwaitingResponse = false;
+        DataState.IsAwaitingResponseStream = false;
         DataState.CancellationTokenSource = new CancellationTokenSource();
     }
+
 }

--- a/src/WebUI/Components/RulesBotChat.razor.cs
+++ b/src/WebUI/Components/RulesBotChat.razor.cs
@@ -1,0 +1,138 @@
+﻿using Blazor.Analytics;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.JSInterop;
+using MudBlazor;
+using OpenAI.GPT3.ObjectModels.RequestModels;
+using WebUI.Models;
+using WebUI.Services;
+
+namespace WebUI.Components;
+
+public class RulesBotChatBase : ComponentBase, IDisposable
+{
+    [Inject] protected DataState DataState { get; set; } = default!;
+    [Inject] protected SswRulesGptDialogService SswRulesGptDialogService { get; set; } = default!;
+    [Inject] protected ApiKeyValidationService ApiKeyValidationService { get; set; } = default!;
+    [Inject] protected NotifierService NotifierService { get; set; } = default!;
+    [Inject] protected SignalRClient SignalR { get; set; } = default!;
+    [Inject] protected IJSRuntime Js { get; set; } = default!;
+    [Inject] protected ISnackbar Snackbar { get; set; } = default!;
+    [Inject] protected IAnalytics Analytics { get; set; } = default!;
+    
+    [CascadingParameter] protected MudTheme Theme { get; set; }
+    [CascadingParameter] protected bool isDarkMode { get; set; }
+    
+    protected override async Task OnInitializedAsync()
+    {
+        NotifierService.Notify += OnNotify;
+        NotifierService.CancelMessageStreamEvent += OnCancelMessageStream;
+    }
+
+    protected async Task OnExampleClicked(string message)
+    {
+        DataState.NewMessageString = message;
+        await SendMessage();
+    }
+
+    protected async Task SendMessage()
+    {
+        if (string.IsNullOrWhiteSpace(DataState.NewMessageString))
+        {
+            return;
+        }
+
+        if (SignalR.GetConnectionState() == SignalRClient.StatusHubConnectionState.Disconnected)
+        {
+            try
+            {
+                await SignalR.StartAsync(DataState.CancellationTokenSource.Token);
+            }
+            catch (HttpRequestException e)
+            {
+                Snackbar.Add("Unable to connect to SSW RulesGPT", Severity.Error);
+                return;
+            }
+        }
+
+        _ = Analytics.TrackEvent("SendMessage", new { message = DataState.NewMessageString, ownKey = DataState.OpenAiApiKey != null });
+
+        var newChatMessage = new ChatMessage("user", DataState.NewMessageString);
+        DataState.NewMessageString = string.Empty;
+        DataState.ChatMessages.Add(newChatMessage);
+
+        var newAssistantMessage = new ChatMessage("assistant", string.Empty);
+
+        DataState.ChatMessages.Add(newAssistantMessage);
+        DataState.IsAwaitingResponseStream = true;
+        DataState.IsAwaitingResponse = true;
+        StateHasChanged();
+
+        await JsScrollMessageListToBottom();
+
+        var resultStream = SignalR.RequestNewCompletionMessage(
+            DataState.ChatMessages,
+            DataState.OpenAiApiKey,
+            DataState.SelectedGptModel,
+            DataState.CancellationTokenSource.Token);
+
+        await JsScrollMessageListToBottom();
+        await foreach (var result in resultStream.WithCancellation(DataState.CancellationTokenSource.Token))
+        {
+            DataState.IsAwaitingResponseStream = false;
+            newAssistantMessage.Content += result?.Content;
+
+            StateHasChanged();
+            _= NotifierService.Update();
+            await Js.InvokeVoidAsync("highlightCode");
+            await JsScrollMessageListToBottom();
+        }
+        DataState.IsAwaitingResponseStream = false;
+        DataState.IsAwaitingResponse = false;
+        DataState.CancellationTokenSource.Dispose();
+        DataState.CancellationTokenSource = new CancellationTokenSource();
+    }
+
+    protected async Task MessageTextFieldHandleEnterKey(KeyboardEventArgs args)
+    {
+        if (args is { Key: "Enter", ShiftKey: false })
+        {
+            await SendMessage();
+        }
+    }
+
+    private async Task OnNotify()
+    {
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task OnCancelMessageStream()
+    {
+        await InvokeAsync(CancelStreamingResponse);
+    }
+    
+    public void Dispose()
+    {
+        NotifierService.Notify -= OnNotify;
+        NotifierService.CancelMessageStreamEvent -= OnCancelMessageStream;
+    }
+
+    private async Task JsScrollMessageListToBottom()
+    {
+        await Js.InvokeVoidAsync("scrollLatestMessageIntoView");
+    }
+
+    private async Task CancelStreamingResponse()
+    {
+        DataState.CancellationTokenSource.Cancel();
+        DataState.CancellationTokenSource.Dispose();
+        var lastAssistantMessage = DataState.ChatMessages.LastOrDefault(s => s.Role == "assistant");
+        if (lastAssistantMessage is not null && string.IsNullOrWhiteSpace(lastAssistantMessage?.Content))
+        {
+            DataState.ChatMessages.Remove(lastAssistantMessage);
+        }
+        DataState.IsAwaitingResponse = false;
+        DataState.IsAwaitingResponseStream = false;
+        DataState.CancellationTokenSource = new CancellationTokenSource();
+    }
+}

--- a/src/WebUI/Models/DataState.cs
+++ b/src/WebUI/Models/DataState.cs
@@ -12,4 +12,5 @@ public class DataState
     public bool UsingByoApiKey { get; set; } = false;
     public bool IsAwaitingResponse { get; set; }
     public bool IsAwaitingResponseStream { get; set; }
+    public string NewMessageString { get; set; } = "";
 }

--- a/src/WebUI/Models/DataState.cs
+++ b/src/WebUI/Models/DataState.cs
@@ -1,15 +1,17 @@
 ﻿using OpenAI.GPT3.ObjectModels.RequestModels;
+using WebUI.Classes;
 
 namespace WebUI.Models;
 
 public class DataState
 {
     public string? OpenAiApiKey { get; set; }
-    public List<ChatMessage> ChatMessages { get; set; } = new();
-    public CancellationTokenSource CancellationTokenSource = new CancellationTokenSource();
+    public ChatLinkedList ChatMessages { get; } = new();
+    public List<ChatLinkedListItem> CurrentMessageThread { get; set; } = new();
+    public CancellationTokenSource CancellationTokenSource { get; set; } = new();
     public OpenAI.GPT3.ObjectModels.Models.Model SelectedGptModel { get; set; } =
         OpenAI.GPT3.ObjectModels.Models.Model.ChatGpt3_5Turbo;
-    public bool UsingByoApiKey { get; set; } = false;
+    public bool UsingByoApiKey { get; set; }
     public bool IsAwaitingResponse { get; set; }
     public bool IsAwaitingResponseStream { get; set; }
     public string NewMessageString { get; set; } = "";

--- a/src/WebUI/Models/DataState.cs
+++ b/src/WebUI/Models/DataState.cs
@@ -10,4 +10,6 @@ public class DataState
     public OpenAI.GPT3.ObjectModels.Models.Model SelectedGptModel { get; set; } =
         OpenAI.GPT3.ObjectModels.Models.Model.ChatGpt3_5Turbo;
     public bool UsingByoApiKey { get; set; } = false;
+    public bool IsAwaitingResponse { get; set; }
+    public bool IsAwaitingResponseStream { get; set; }
 }

--- a/src/WebUI/Services/SswRulesGptDialogService.cs
+++ b/src/WebUI/Services/SswRulesGptDialogService.cs
@@ -23,7 +23,6 @@ public class SswRulesGptDialogService
             MaxWidth = MaxWidth.ExtraSmall
         };
         var dialog = await _dialogService.ShowAsync<ApiKeyDialog>("API Key", options);
-        var result = await dialog.Result;
         var success = dialog.Result.IsCompletedSuccessfully;
         return success;
     }
@@ -39,8 +38,19 @@ public class SswRulesGptDialogService
             MaxWidth = MaxWidth.Large
         };
         var dialog = await _dialogService.ShowAsync<AboutAppDialog>(string.Empty, options);
-        var result = await dialog.Result;
         var success = dialog.Result.IsCompletedSuccessfully;
         return success;
+    }
+
+    public async Task<bool> EditMessageDialog()
+    {
+        var options = new DialogOptions
+        {
+            CloseOnEscapeKey = true,
+            Position = DialogPosition.TopCenter
+        };
+        
+        var result = await _dialogService.Show<EditMessageDialog>("Are you sure?", options).Result;
+        return !result.Canceled;
     }
 }


### PR DESCRIPTION
Closes #55 

Moved the chat bubble into its own component
Added a button beside each user message that is shown when the message is hovered
When the button is clicked a message can be edited and resent
The old message will be preserved and the user can navigate between the threads. The threads can have any number of branches

![image](https://github.com/SSWConsulting/SSW.Rules.GPT/assets/10693364/85927395-1544-4071-a7c7-aef45f3330d3)
**Figure: The edit button** 

![image](https://github.com/SSWConsulting/SSW.Rules.GPT/assets/10693364/54c138ba-159f-45cd-bb79-756598a58c7c)
**Figure: The controls to switch between versions of a message**
