### PR TITLE
✨ 79 - Allow multiline input in chat box

### DIFF
--- a/src/WebUI/Components/MultilineInput.razor
+++ b/src/WebUI/Components/MultilineInput.razor
@@ -5,7 +5,7 @@
 @code {
     [Parameter] public string Data { get; set; } = default!;
     [Parameter] public EventCallback<string> OnSubmitted { get; set; }
-    
+
     private string message = "";
 
     public async Task Submit()

--- a/src/WebUI/Components/MultilineInput.razor.css
+++ b/src/WebUI/Components/MultilineInput.razor.css
@@ -1,5 +1,6 @@
 ﻿.container {
     display: grid;
+    width: 100%;
 }
 
 .container:after {

--- a/src/WebUI/Components/RulesBotChat.razor
+++ b/src/WebUI/Components/RulesBotChat.razor
@@ -45,7 +45,7 @@
         </MudPopover>
     </MudPaper>
     <MudStack Row="true" Class="mt-3">
-        <MudTextField Style="height: 100%;" Clearable="true" Disabled="DataState.IsAwaitingResponse" Class="mt-0" @bind-Value="DataState.NewMessageString" OnKeyDown="MessageTextFieldHandleEnterKey" Immediate="true" Label="Ask a question!" Variant="Variant.Outlined"></MudTextField>
+        <MudTextField Lines="5" Style="height: 100%;" Clearable="true" Disabled="DataState.IsAwaitingResponse" Class="mt-0 chat-input" @bind-Value="DataState.NewMessageString" OnKeyDown="MessageTextFieldHandleEnterKey" Immediate="true" Label="Ask a question!" Variant="Variant.Outlined"></MudTextField>
         <MudButton Color="Color.Secondary" Variant="Variant.Filled" OnClick="SendMessage">
             <MudIcon Icon="@Icons.Material.Filled.Send"></MudIcon>
         </MudButton>

--- a/src/WebUI/Components/RulesBotChat.razor
+++ b/src/WebUI/Components/RulesBotChat.razor
@@ -45,7 +45,7 @@
         </MudPopover>
     </MudPaper>
     <MudStack Row="true" Class="mt-3">
-        <MudTextField Lines="5" Style="height: 100%;" Clearable="true" Disabled="DataState.IsAwaitingResponse" Class="mt-0 chat-input" @bind-Value="DataState.NewMessageString" OnKeyDown="MessageTextFieldHandleEnterKey" Immediate="true" Label="Ask a question!" Variant="Variant.Outlined"></MudTextField>
+        <MudTextField Lines="5" Style="height: 100%;" id="chat-input" Clearable="true" Disabled="DataState.IsAwaitingResponse" @bind-Value="DataState.NewMessageString" OnKeyDown="MessageTextFieldHandleEnterKey" Immediate="true" Label="Ask a question!" Variant="Variant.Outlined"></MudTextField>
         <MudButton Color="Color.Secondary" Variant="Variant.Filled" OnClick="SendMessage">
             <MudIcon Icon="@Icons.Material.Filled.Send"></MudIcon>
         </MudButton>

--- a/src/WebUI/Components/RulesBotChat.razor.cs
+++ b/src/WebUI/Components/RulesBotChat.razor.cs
@@ -31,6 +31,16 @@ public class RulesBotChatBase : ComponentBase, IDisposable
         NotifierService.CancelMessageStreamEvent += OnCancelMessageStream;
     }
 
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await base.OnAfterRenderAsync(firstRender);
+        
+        if (firstRender)
+        {
+            await Js.InvokeVoidAsync("initInputHeight");
+        }
+    }
+    
     protected async Task OnExampleClicked(string message)
     {
         DataState.NewMessageString = message;
@@ -104,6 +114,7 @@ public class RulesBotChatBase : ComponentBase, IDisposable
         StateHasChanged();
 
         await JsScrollMessageListToBottom();
+        await Js.InvokeVoidAsync("setInputHeight");
 
         var resultStream = SignalR.RequestNewCompletionMessage(
             DataState.CurrentMessageThread.Select(s => s.Message).ToList(),
@@ -149,6 +160,7 @@ public class RulesBotChatBase : ComponentBase, IDisposable
 
     protected async Task MessageTextFieldHandleEnterKey(KeyboardEventArgs args)
     {
+        
         if (args is { Key: "Enter", ShiftKey: false })
         {
             await SendMessage();

--- a/src/WebUI/wwwroot/index.html
+++ b/src/WebUI/wwwroot/index.html
@@ -94,6 +94,25 @@
             }
         };
     </script>
+    <script>
+        let input;
+        
+        window.initInputHeight = () => {
+            input = document.querySelector('.chat-input textarea');
+            input.addEventListener('input', window.setInputHeight);
+            setInputHeight();
+        };
+        
+        window.setInputHeight = () => {
+            let text = input.value;
+            let number = text.split(/\r\n|\r|\n/).length;
+            
+            //Constrain number between 1 and 5
+            number = Math.min(Math.max(number, 1), 5);
+            
+            input.setAttribute('rows', number.toString());
+        };
+    </script>
 </body>
 
 </html>

--- a/src/WebUI/wwwroot/index.html
+++ b/src/WebUI/wwwroot/index.html
@@ -98,7 +98,7 @@
         let input;
         
         window.initInputHeight = () => {
-            input = document.querySelector('.chat-input textarea');
+            input = document.getElementById("chat-input");
             input.addEventListener('input', window.setInputHeight);
             setInputHeight();
         };


### PR DESCRIPTION
Closes #79 

The chat input now allows multiple lines and responds to Shift + Enter.
Had to use JS to achieve this due to the way MudBlazor handles its text field internally, if 'Lines' is set to 1 on the MudTextField it uses a standard input tag which will not respond to multiline input, and only uses a textarea if it is set to >1.

The maximum height for the input is set at 5 rows.

![image](https://github.com/SSWConsulting/SSW.Rules.GPT/assets/10693364/bcaeae80-3ccc-44a3-a33d-696919ab6451)
