### PR TITLE
✨ Add instructions modal in the settings menu

### DIFF
--- a/src/WebUI/Components/InstallInstructionDialog.razor
+++ b/src/WebUI/Components/InstallInstructionDialog.razor
@@ -1,0 +1,70 @@
+﻿<MudDialog>
+    <TitleContent>
+        <MudText Typo="Typo.h6">Install RulesGPT</MudText>
+    </TitleContent>
+    <DialogContent>
+        <MudTabs Rounded="true" Elevation="4" Color="Color.Error" ApplyEffectsToContainer="true">
+            <MudTabPanel Text="Windows (Edge)">
+                <ol class="ml-8 my-4">
+                    <li>
+                        <MudText>
+                            Open the
+                            <MudIcon Style="vertical-align: bottom;" Icon="@Icons.Material.Filled.MoreHoriz"/>
+                            menu in the top right corner of your browser.
+                        </MudText>
+                    </li>
+                    <li>
+                        <MudText>Open the 'Apps' menu.</MudText>
+                    </li>
+                    <li>
+                        <MudText>Click 'Install this site as an app'.</MudText>
+                    </li>
+                </ol>
+            </MudTabPanel>
+            <MudTabPanel Text="iOS (Safari)">
+                <ol class="ml-8 my-4">
+                    <li>
+                        <MudText>
+                            Open the Share
+                            <MudIcon Style="vertical-align: text-bottom;" Icon="@Icons.Material.Filled.IosShare"/>
+                            menu.
+                        </MudText>
+                    </li>
+                    <li>
+                        <MudText>Select the 'Add to Home Screen' option.</MudText>
+                    </li>
+                    <li>
+                        <MudText>Press 'Add'.</MudText>
+                    </li>
+                </ol>
+
+            </MudTabPanel>
+            <MudTabPanel Text="Android">
+                <ol class="ml-8 my-4">
+                    <li>
+                        <MudText>
+                            Open the
+                            <MudIcon Style="vertical-align: bottom;" Icon="@Icons.Material.Filled.MoreHoriz"/>
+                            menu.
+                        </MudText>
+                    </li>
+                    <li>
+                        <MudText>Press 'Add to Home screen'.</MudText>
+                    </li>
+                    <li>
+                        <MudText>Press 'Add'.</MudText>
+                    </li>
+                </ol>
+            </MudTabPanel>
+        </MudTabs>
+    </DialogContent>
+    <DialogActions>
+
+    </DialogActions>
+</MudDialog>
+
+@code {
+
+    [CascadingParameter]
+    MudDialogInstance MudDialog { get; set; } = default!;
+}

--- a/src/WebUI/Services/SswRulesGptDialogService.cs
+++ b/src/WebUI/Services/SswRulesGptDialogService.cs
@@ -42,6 +42,21 @@ public class SswRulesGptDialogService
         return success;
     }
 
+    public async Task<bool> InstallInstructionsDialog()
+    {
+        var options = new DialogOptions
+        {
+            CloseOnEscapeKey = true,
+            CloseButton = true,
+            DisableBackdropClick = false,
+            NoHeader = false,
+            MaxWidth = MaxWidth.Large
+        };
+        var dialog = await _dialogService.ShowAsync<InstallInstructionDialog>(string.Empty, options);
+        var success = dialog.Result.IsCompletedSuccessfully;
+        return success;
+    }
+
     public async Task<bool> EditMessageDialog()
     {
         var options = new DialogOptions

--- a/src/WebUI/Shared/MainLayout.razor
+++ b/src/WebUI/Shared/MainLayout.razor
@@ -54,6 +54,7 @@
         <MudMenu Icon="@Icons.Material.Filled.Settings" Dense="false" Color="Color.Inherit" AnchorOrigin="Origin.BottomRight" TransformOrigin="Origin.TopRight">
             <MudMenuItem IconSize="Size.Small" Icon="@Icons.Material.Filled.Edit" OnTouch="OpenApiKeyDialog" OnClick="OpenApiKeyDialog">API Key</MudMenuItem>
             <MudMenuItem IconSize="Size.Small" Icon="@Icons.Material.Filled.SettingsSuggest" Target="_blank" Href="https://github.com/SSWConsulting/SSW.Rules.GPT.Blazor/issues">Suggestions</MudMenuItem>
+            <MudMenuItem IconSize="Size.Small" Icon="@Icons.Material.Filled.Download" OnTouch="OpenInstallInstructionsDialog" OnClick="OpenInstallInstructionsDialog">Installation Instructions</MudMenuItem>
             <MudMenuItem IconSize="Size.Small" Icon="@Icons.Material.Filled.Info" OnTouch="OpenAboutRulesGptDialog" OnClick="OpenAboutRulesGptDialog">About</MudMenuItem>
         </MudMenu>
     </MudAppBar>
@@ -147,12 +148,17 @@
 
     private async Task OpenApiKeyDialog()
     {
-        var success = await SswRulesGptDialogService.ApiKeyDialog();
+        await SswRulesGptDialogService.ApiKeyDialog();
     }
 
     private async Task OpenAboutRulesGptDialog()
     {
-        var success = await SswRulesGptDialogService.AboutRulesGptDialog();
+        await SswRulesGptDialogService.AboutRulesGptDialog();
+    }
+
+    private async Task OpenInstallInstructionsDialog()
+    {
+        await SswRulesGptDialogService.InstallInstructionsDialog();
     }
 
     private async Task ClearMessageHistory()


### PR DESCRIPTION
Closes #83 

Added a dialog with instructions to install the website as an application on different platforms.

![image](https://github.com/SSWConsulting/SSW.Rules.GPT/assets/10693364/38fca300-4adb-42d2-9ca4-fdd64a46951f)
