### PR TITLE
Update system prompt to only use full rule URL once

### DIFF
--- a/src/Application/Services/MessageHandler.cs
+++ b/src/Application/Services/MessageHandler.cs
@@ -76,7 +76,7 @@ Subject: {{ SUBJECT }}
 Body: {{ BODY }}
     
 You should use the phrase "As per https://ssw.com.au/rules/<ruleName>" at the start of the response 
-when you are referring to data sourced from a rule above (make sure it is a URL - only include this if it is a rule name in the provided reference data) 🤓. 
+when you are referring to data sourced from a rule above (make sure it is a URL the first time you reference it, after that use the rule name - only include this if it is a rule name in the provided reference data) 🤓. 
 Don't forget the emojis!!! Try to include at least 1 reference if relevant, but use as many as are required!
 Ask the user for more details if it would help inform the response.
 """;


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->
Update the system prompt to tell GPT to only use the full URL once in its response.

Related to #106 

<!-- 🚨 As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->
