### PR TITLE
👷 Remove push to main trigger from production workflow

### DIFF
--- a/.github/workflows/main-build-deploy.yml
+++ b/.github/workflows/main-build-deploy.yml
@@ -4,9 +4,6 @@
 name: Build and deploy - ssw-rulesgpt-prod
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
     
 env:

--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ Follow these simple steps to install and set up our SSW Rules GPT project:
 Instead of manually launching the WebUI and WebAPI projects, you can set multiple startup projects in Visual Studio and Rider.  
 Read [this rule](https://ssw.com.au/rules/multiple-startup-projects/) to learn how.
 
+### 🚀 Deployment
+When code merged into main it will be automatically deployed to staging.
+You should test your changes in staging before manually running the production workflow.
+
+Staging Frontend URL: https://ashy-meadow-0a2bad900.3.azurestaticapps.net
+Staging API URL: https://ssw-rulesgpt-api-stage.azurewebsites.net
+
 ### 👥 Project Contributors
 
 - Calum Simpson ([@calumjs](https://github.com/calumjs))

--- a/src/WebAPI/DependencyInjection.cs
+++ b/src/WebAPI/DependencyInjection.cs
@@ -39,7 +39,6 @@ public static class DependencyInjection
         // TODO: Set CORS in Bicep
         var productionCorsUrls = new string[]
         {
-            "https://ashy-meadow-0a2bad900.3.azurestaticapps.net",
             "https://white-desert-00e3fb600.3.azurestaticapps.net",
             "https://rulesgpt.ssw.com.au",
             "https://ssw.com.au/rulesgpt"

--- a/src/WebAPI/DependencyInjection.cs
+++ b/src/WebAPI/DependencyInjection.cs
@@ -39,6 +39,7 @@ public static class DependencyInjection
         // TODO: Set CORS in Bicep
         var productionCorsUrls = new string[]
         {
+            "https://ashy-meadow-0a2bad900.3.azurestaticapps.net",
             "https://white-desert-00e3fb600.3.azurestaticapps.net",
             "https://rulesgpt.ssw.com.au",
             "https://ssw.com.au/rulesgpt"


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->

Related to #113 

Remove push to main trigger from production workflow and update readme with details.
Deploying to prod will now be a manual step.

<!-- 🚨 As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->
