### PR TITLE
🐛 Fix wrong audience name

### DIFF
--- a/src/WebAPI/Program.cs
+++ b/src/WebAPI/Program.cs
@@ -20,7 +20,7 @@ builder.Services.AddAuthentication(options =>
 }).AddJwtBearer(options =>
 {
     options.Authority = signingAuthority;
-    options.Audience = "ssw-rulesgpt";
+    options.Audience = "rulesgpt";
     options.TokenValidationParameters.ValidTypes = new[] { "at+jwt" };
 
     options.Events = new JwtBearerEvents


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->

Related to #128 

The audience name on the API was wrong which was causing validation to fail and authenticated users to be treated as unauthenticated by the backend.

<!-- 🚨 As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->
