### PR TITLE
🐛 Check if user is authenticated before reverting to gpt-3.5

### DIFF
--- a/src/WebUI/Components/Dialogs/ApiKeyDialog.razor
+++ b/src/WebUI/Components/Dialogs/ApiKeyDialog.razor
@@ -105,8 +105,10 @@
         if (!UsingByoApiKey)
         {
             DataState.ApiKeyString = null;
-            DataState.SelectedGptModel = AvailableGptModels.Gpt35Turbo;
             DataState.UsingByoApiKey = false;
+            DataState.SelectedGptModel = UserService.IsUserAuthenticated 
+                ? SelectedGptModel
+                : AvailableGptModels.Gpt35Turbo;
 
             await Storage.SetItemAsync("userAPIKeyEnabled", DataState.UsingByoApiKey.ToString());
         }


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->
Check if user is authenticated when not using own key before reverting to gpt-3.5

Related to #133 

<!-- 🚨 As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->
