### PR TITLE
🐛 Fix header responsiveness

### DIFF
--- a/src/WebUI/Shared/MainLayout.razor
+++ b/src/WebUI/Shared/MainLayout.razor
@@ -49,15 +49,13 @@
 
                     break;
 
+                default:
                 case ThemePreference.System:
                     <MudTooltip Duration="1000" Text="Switch to Light Theme">
                         <MudIconButton Icon="@Icons.Material.Rounded.LightMode" Color="Color.Inherit" OnClick="@(() => SetThemePreference(ThemePreference.Light))"/>
                     </MudTooltip>
-
+                    
                     break;
-
-                default:
-                    goto case ThemePreference.Light;
             }
             <MudTooltip Duration="1000" Text="Start a New Chat">
                 <MudIconButton Icon="@Icons.Material.Rounded.Refresh" Color="Color.Inherit" OnClick="@ResetApplicationState"/>
@@ -77,15 +75,13 @@
                         break;
 
                     case ThemePreference.Dark:
-                        <MudMenuItem IconSize="Size.Small" Icon="@Icons.Material.Filled.DarkMode" OnTouch="@(() => SetThemePreference(ThemePreference.Dark))" OnClick="@(() => SetThemePreference(ThemePreference.Dark))">Use System Theme</MudMenuItem>
-                        break;
-
-                    case ThemePreference.System:
-                        <MudMenuItem IconSize="Size.Small" Icon="@Icons.Material.Filled.DarkMode" OnTouch="@(() => SetThemePreference(ThemePreference.Dark))" OnClick="@(() => SetThemePreference(ThemePreference.Light))">Use Light Theme</MudMenuItem>
+                        <MudMenuItem IconSize="Size.Small" Icon="@Icons.Material.Filled.DarkMode" OnTouch="@(() => SetThemePreference(ThemePreference.Dark))" OnClick="@(() => SetThemePreference(ThemePreference.System))">Use System Theme</MudMenuItem>
                         break;
 
                     default:
-                        goto case ThemePreference.Light;
+                    case ThemePreference.System:
+                        <MudMenuItem IconSize="Size.Small" Icon="@Icons.Material.Filled.DarkMode" OnTouch="@(() => SetThemePreference(ThemePreference.Dark))" OnClick="@(() => SetThemePreference(ThemePreference.Light))">Use Light Theme</MudMenuItem>
+                        break;
                 }
 
             </MudMenu>

--- a/src/WebUI/Shared/MainLayout.razor
+++ b/src/WebUI/Shared/MainLayout.razor
@@ -27,38 +27,12 @@
                 </MudStack>
             </MudStack>
         </a>
-        <MudStack Justify="Justify.Center" Class="pl-3 order">
-            <MudText Class="tag-line" Color="Color.Primary" Typo="Typo.body1">Keeping Order with Intelligence</MudText>
+        <MudStack Justify="Justify.Center" Class="pl-3">
+            <MudText Class="d-none d-lg-flex" Color="Color.Primary" Typo="Typo.body1">Keeping Order with Intelligence</MudText>
         </MudStack>
         <MudSpacer/>
-        <MudLink Color="Color.Primary" Variant="Variant.Filled" Class="mr-2 powered-by-link tl" Target="_blank" Href="https://ssw.com.au/rules">Powered by SSW Rules</MudLink>
-        <style>
-            .small-nav {
-                display: none !important;
-            }
-        
-            @@media screen and (max-width: 950px)  {
-                .order {
-                    display: none !important;
-                }
-            }
-            
-            @@media screen and (max-width: 750px)  {
-                .tl {
-                    display: none !important;
-                }
-            }
-            
-            @@media screen and (max-width: 600px) {
-                .wide-nav {
-                    display: none !important;
-                }
-                .small-nav {
-                    display: unset !important;
-                }
-            }
-        </style>
-        <div class="wide-nav">
+        <MudLink Color="Color.Primary" Variant="Variant.Filled" Class="mr-2 powered-by-link d-none d-md-flex" Target="_blank" Href="https://ssw.com.au/rules">Powered by SSW Rules</MudLink>
+        <div class="d-none d-md-flex">
             @switch (themePreference)
             {
                 case ThemePreference.Light:
@@ -92,7 +66,7 @@
                 <MudIconButton Icon="@Icons.Material.Rounded.Leaderboard" Color="Color.Inherit" OnClick="@(() => NavigationManager.NavigateTo("/leaderboard"))"/>
             </MudTooltip>
         </div>
-        <div class="small-nav">
+        <div class="d-sm-flex d-md-none">
             <MudMenu Icon="@Icons.Material.Filled.KeyboardArrowDown" Color="Color.Inherit" AnchorOrigin="Origin.BottomRight" TransformOrigin="Origin.TopRight">
                 <MudMenuItem IconSize="Size.Small" Icon="@Icons.Material.Filled.Refresh" OnTouch="ResetApplicationState" OnClick="ResetApplicationState">New Chat</MudMenuItem>
                 <MudMenuItem IconSize="Size.Small" Icon="@Icons.Material.Filled.Leaderboard" OnTouch="@(() => NavigationManager.NavigateTo("/leaderboard"))" OnClick="@(() => NavigationManager.NavigateTo("/leaderboard"))">Leaderboard</MudMenuItem>

--- a/src/WebUI/Shared/MainLayout.razor
+++ b/src/WebUI/Shared/MainLayout.razor
@@ -27,43 +27,95 @@
                 </MudStack>
             </MudStack>
         </a>
-        <MudStack Justify="Justify.Center" Class="pl-3">
+        <MudStack Justify="Justify.Center" Class="pl-3 order">
             <MudText Class="tag-line" Color="Color.Primary" Typo="Typo.body1">Keeping Order with Intelligence</MudText>
         </MudStack>
         <MudSpacer/>
-        <MudLink Color="Color.Primary" Variant="Variant.Filled" Class="mr-2 powered-by-link" Target="_blank" Href="https://ssw.com.au/rules">Powered by SSW Rules</MudLink>
-        @switch (themePreference)
-        {
-            case ThemePreference.Light:
-                <MudTooltip Duration="1000" Text="Switch to Dark Theme">
-                    <MudIconButton Icon="@Icons.Material.Rounded.DarkMode" Color="Color.Inherit" OnClick="@(() => SetThemePreference(ThemePreference.Dark))"/>
-                </MudTooltip>
+        <MudLink Color="Color.Primary" Variant="Variant.Filled" Class="mr-2 powered-by-link tl" Target="_blank" Href="https://ssw.com.au/rules">Powered by SSW Rules</MudLink>
+        <style>
+            .small-nav {
+                display: none !important;
+            }
+        
+            @@media screen and (max-width: 950px)  {
+                .order {
+                    display: none !important;
+                }
+            }
+            
+            @@media screen and (max-width: 750px)  {
+                .tl {
+                    display: none !important;
+                }
+            }
+            
+            @@media screen and (max-width: 600px) {
+                .wide-nav {
+                    display: none !important;
+                }
+                .small-nav {
+                    display: unset !important;
+                }
+            }
+        </style>
+        <div class="wide-nav">
+            @switch (themePreference)
+            {
+                case ThemePreference.Light:
+                    <MudTooltip Duration="1000" Text="Switch to Dark Theme">
+                        <MudIconButton Icon="@Icons.Material.Rounded.DarkMode" Color="Color.Inherit" OnClick="@(() => SetThemePreference(ThemePreference.Dark))"/>
+                    </MudTooltip>
 
-                break;
+                    break;
 
-            case ThemePreference.Dark:
-                <MudTooltip Duration="1000" Text="Switch to System Theme">
-                    <MudIconButton Icon="@Icons.Material.Rounded.Devices" Color="Color.Inherit" OnClick="@(() => SetThemePreference(ThemePreference.System))"/>
-                </MudTooltip>
+                case ThemePreference.Dark:
+                    <MudTooltip Duration="1000" Text="Switch to System Theme">
+                        <MudIconButton Icon="@Icons.Material.Rounded.Devices" Color="Color.Inherit" OnClick="@(() => SetThemePreference(ThemePreference.System))"/>
+                    </MudTooltip>
 
-                break;
+                    break;
 
-            case ThemePreference.System:
-                <MudTooltip Duration="1000" Text="Switch to Light Theme">
-                    <MudIconButton Icon="@Icons.Material.Rounded.LightMode" Color="Color.Inherit" OnClick="@(() => SetThemePreference(ThemePreference.Light))"/>
-                </MudTooltip>
+                case ThemePreference.System:
+                    <MudTooltip Duration="1000" Text="Switch to Light Theme">
+                        <MudIconButton Icon="@Icons.Material.Rounded.LightMode" Color="Color.Inherit" OnClick="@(() => SetThemePreference(ThemePreference.Light))"/>
+                    </MudTooltip>
 
-                break;
+                    break;
 
-            default:
-                goto case ThemePreference.Light;
-        }
-        <MudTooltip Duration="1000" Text="Start a New Chat">
-            <MudIconButton Icon="@Icons.Material.Rounded.Refresh" Color="Color.Inherit" OnClick="@ResetApplicationState"/>
-        </MudTooltip>
-        <MudTooltip Duration="1000" Text="Leaderboard">
-            <MudIconButton Icon="@Icons.Material.Rounded.Leaderboard" Color="Color.Inherit" OnClick="@(() => NavigationManager.NavigateTo("/leaderboard"))"/>
-        </MudTooltip>
+                default:
+                    goto case ThemePreference.Light;
+            }
+            <MudTooltip Duration="1000" Text="Start a New Chat">
+                <MudIconButton Icon="@Icons.Material.Rounded.Refresh" Color="Color.Inherit" OnClick="@ResetApplicationState"/>
+            </MudTooltip>
+            <MudTooltip Duration="1000" Text="Leaderboard">
+                <MudIconButton Icon="@Icons.Material.Rounded.Leaderboard" Color="Color.Inherit" OnClick="@(() => NavigationManager.NavigateTo("/leaderboard"))"/>
+            </MudTooltip>
+        </div>
+        <div class="small-nav">
+            <MudMenu Icon="@Icons.Material.Filled.KeyboardArrowDown" Color="Color.Inherit" AnchorOrigin="Origin.BottomRight" TransformOrigin="Origin.TopRight">
+                <MudMenuItem IconSize="Size.Small" Icon="@Icons.Material.Filled.Refresh" OnTouch="ResetApplicationState" OnClick="ResetApplicationState">New Chat</MudMenuItem>
+                <MudMenuItem IconSize="Size.Small" Icon="@Icons.Material.Filled.Leaderboard" OnTouch="@(() => NavigationManager.NavigateTo("/leaderboard"))" OnClick="@(() => NavigationManager.NavigateTo("/leaderboard"))">Leaderboard</MudMenuItem>
+                @switch (themePreference)
+                {
+                    case ThemePreference.Light:
+                        <MudMenuItem IconSize="Size.Small" Icon="@Icons.Material.Filled.DarkMode" OnTouch="@(() => SetThemePreference(ThemePreference.Dark))" OnClick="@(() => SetThemePreference(ThemePreference.Dark))">Use Dark Theme</MudMenuItem>
+                        break;
+
+                    case ThemePreference.Dark:
+                        <MudMenuItem IconSize="Size.Small" Icon="@Icons.Material.Filled.DarkMode" OnTouch="@(() => SetThemePreference(ThemePreference.Dark))" OnClick="@(() => SetThemePreference(ThemePreference.Dark))">Use System Theme</MudMenuItem>
+                        break;
+
+                    case ThemePreference.System:
+                        <MudMenuItem IconSize="Size.Small" Icon="@Icons.Material.Filled.DarkMode" OnTouch="@(() => SetThemePreference(ThemePreference.Dark))" OnClick="@(() => SetThemePreference(ThemePreference.Light))">Use Light Theme</MudMenuItem>
+                        break;
+
+                    default:
+                        goto case ThemePreference.Light;
+                }
+
+            </MudMenu>
+        </div>
         <MudMenu Icon="@Icons.Material.Filled.Settings" Dense="false" Color="Color.Inherit" AnchorOrigin="Origin.BottomRight" TransformOrigin="Origin.TopRight">
             <MudMenuItem IconSize="Size.Small" Icon="@Icons.Material.Filled.Edit" OnTouch="OpenApiKeyDialog" OnClick="OpenApiKeyDialog">API Key</MudMenuItem>
             <MudMenuItem IconSize="Size.Small" Icon="@Icons.Material.Filled.SettingsSuggest" Target="_blank" Href="https://github.com/SSWConsulting/SSW.Rules.GPT.Blazor/issues">Suggestions</MudMenuItem>
@@ -137,7 +189,7 @@
 
     protected override async Task OnInitializedAsync()
     {
-        //Will default to 'light' if no stored value is found
+    //Will default to 'light' if no stored value is found
         themePreference = await Storage.GetItemAsync<ThemePreference>("DarkModePreference");
         SetThemePreference(themePreference);
 
@@ -147,7 +199,7 @@
         }
         catch (HttpRequestException e)
         {
-            // Display error message
+    // Display error message
             Snackbar.Add("Unable to connect to SSW RulesGPT", Severity.Error);
         }
 
@@ -158,7 +210,7 @@
         var savedAPIKey = await Storage.GetItemAsync<string>("userAPIKey");
         var savedModel = await Storage.GetItemAsync<string>("userGptModel");
 
-        //useSavedKey should be ignored if there is no key saved
+    //useSavedKey should be ignored if there is no key saved
         if (!string.IsNullOrEmpty(savedAPIKey) && useSavedKeyParsed && useSavedKey)
         {
             DataState.ApiKeyString = savedAPIKey;


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->
The site was not responsive on smaller screens, meaning mobile users are unable to sign in or access the leaderboard.

Related to #142 

![image](https://github.com/SSWConsulting/SSW.Rules.GPT/assets/10693364/8432c6b8-4623-4c04-a98b-48d18c387501)
**Figure: Before - menu options such as sign in, leaderboard and new chat are not visible**

![image](https://github.com/SSWConsulting/SSW.Rules.GPT/assets/10693364/ec521d22-b21a-4388-97ab-375650593c6f)
**Figure: After: All elements fit properly on screen**

![image](https://github.com/SSWConsulting/SSW.Rules.GPT/assets/10693364/e78cd5ac-2e8f-49d0-9783-bd9fb2e85251)
**Figure: Icon buttons move to a dropdown on smaller screens**

<!-- 🚨 As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->
