### PR TITLE
♻️ Add sign in prompt when not signed in

### DIFF
--- a/src/WebUI/Components/ChatItem.razor
+++ b/src/WebUI/Components/ChatItem.razor
@@ -89,6 +89,13 @@
                 <MudText Typo="Typo.body1">
                     <b>RulesGPT</b> - @(MessageThreadItem.GptModel.AvailableModelEnumToString())
                 </MudText>
+                <AuthorizeView>
+                    <NotAuthorized>
+                        <MudText Typo="Typo.caption">
+                            ⚠️ Sign in for free GPT-4 access
+                        </MudText>
+                    </NotAuthorized>
+                </AuthorizeView>
                 @if (DataState.IsAwaitingResponseStream && string.IsNullOrWhiteSpace(MessageThreadItem.Message.Content))
                 {
                     <MudPaper Elevation="1" Class="px-4 py-3" Style="text-align: center;">


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->
Cc: @adamcogan 

Related to #145 

* Message displays whenever user is not signed in.
* Added underneath the model instead of next to it for responsiveness.
* Changed wording to cover cases where user may be using their own GPT-4 key but not signed in

![image](https://github.com/SSWConsulting/SSW.Rules.GPT/assets/10693364/febede8f-b7bc-4298-9659-0feb439dd13e)
**Figure: Message now displayed when user is not signed in**

<!-- 🚨 As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->
