### PR TITLE
💄 Add width constraint to leaderboard position column

### DIFF
--- a/src/WebUI/Pages/Leaderboard.razor
+++ b/src/WebUI/Pages/Leaderboard.razor
@@ -42,6 +42,11 @@
             </MudButton>
         </MudButtonGroup>
         <MudTable Items="@LeaderboardData" T="OrderedLeaderboardUser">
+            <ColGroup>
+                <col style="width: 60px;"/>
+                <col/>
+                <col/>
+            </ColGroup>
             <HeaderContent>
                 <MudTh>Position</MudTh>
                 <MudTh>Name</MudTh>
@@ -92,7 +97,7 @@
             LastYear = s.LastYear,
             AllTime = s.AllTime
         })
-        .ToList();
+            .ToList();
 
         HandleFilterChanged(LeaderboardFilter.LastMonth);
 
@@ -103,7 +108,7 @@
     {
         Filter = filter;
 
-        //ThenByDescending ensures that if two users have the same number of messages sent this month/year, the one with the higher all time score ranks higher
+    //ThenByDescending ensures that if two users have the same number of messages sent this month/year, the one with the higher all time score ranks higher
         LeaderboardData = Filter switch {
             LeaderboardFilter.LastMonth => LeaderboardData
                 .OrderByDescending(s => s.LastMonth)


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->
Limits the position column width to 60px.

Related to #143 

![image](https://github.com/SSWConsulting/SSW.Rules.GPT/assets/10693364/c41bfa3f-eecf-4571-a6f0-460db5168e02)
**Figure: The new width of the column**

<!-- 🚨 As per rule https://www.ssw.com.au/rules/over-the-shoulder-prs -->
<!-- Getting the PR merged is part of the PBI - Call someone to review your changes to get them merged ASAP -->
