### PR TITLE
🐛 Fix Json Capitalisation

### DIFF
--- a/src/Domain/Entities/LeaderboardUser.cs
+++ b/src/Domain/Entities/LeaderboardUser.cs
@@ -2,8 +2,8 @@
 
 public class LeaderboardUser
 {
-    public string Name { get; set; } = null!;
-    public string Email { get; set; } = null!;
+    public required string Name { get; set; }
+    public required string Email { get; set; }
     
     public int LastMonth { get; set; }
     public int LastYear { get; set; }

--- a/src/WebAPI/DependencyInjection.cs
+++ b/src/WebAPI/DependencyInjection.cs
@@ -18,6 +18,10 @@ public static class DependencyInjection
         services.AddHttpContextAccessor();
         services.AddScoped<ICurrentUserService, CurrentUserService>();
         
+        services.ConfigureHttpJsonOptions(options =>
+        {
+            options.SerializerOptions.PropertyNamingPolicy = null; // Override camelCase with PascalCase
+        });
         services.AddSingleton<SignalRHubFilter>();
 
         services.AddSignalR(options => options.AddFilter<SignalRHubFilter>());

--- a/src/WebAPI/Routes/LeaderboardRoutes.cs
+++ b/src/WebAPI/Routes/LeaderboardRoutes.cs
@@ -8,7 +8,7 @@ public static class LeaderboardRoutes
 {
     public static void MapLeaderboardRoutes(this WebApplication app)
     {
-        var routeGroup = app.MapGroup("").WithTags("Leaderboard");
+        var routeGroup = app.MapGroup("leaderboard").WithTags("Leaderboard");
 
         routeGroup
             .MapGet(

--- a/src/WebUI/Properties/launchSettings.json
+++ b/src/WebUI/Properties/launchSettings.json
@@ -10,6 +10,16 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
+    },
+    "(Watch)": {
+      "commandName": "Executable",
+      "executablePath": "dotnet",
+      "workingDirectory": "$(ProjectDir)",
+      "commandLineArgs": "watch run",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_WATCH_RESTART_ON_RUDE_EDIT": "true"
+      }
     }
   }
 }

--- a/src/WebUI/RulesGptApiClients.cs
+++ b/src/WebUI/RulesGptApiClients.cs
@@ -71,8 +71,8 @@ namespace WebUI
 
                     var urlBuilder_ = new System.Text.StringBuilder();
                 
-                    // Operation Path: "getLeaderboardStats"
-                    urlBuilder_.Append("getLeaderboardStats");
+                    // Operation Path: "leaderboard/getLeaderboardStats"
+                    urlBuilder_.Append("leaderboard/getLeaderboardStats");
 
                     PrepareRequest(client_, request_, urlBuilder_);
 


### PR DESCRIPTION
<!-- describe the change, why is it needed and what does it accomplish  -->
.NET 8 made camelCase the default for System.Text.Json serialisation. set it back to PascalCase.
Add .net watch launch profile for Blazor.
Closes #164 
Closes #165  

